### PR TITLE
Upgrade langchain and openai versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-langchain==0.0.149
+langchain==0.0.316
 python-dotenv==1.0.0
 supabase==1.0.3
 tiktoken==0.3.3
-openai
+openai==0.28.1
 dotenv


### PR DESCRIPTION
With the current versions of these packages you run into:

`AttributeError: module 'openai' has no attribute 'error'`

When you run `python embed.py`. Upgrading the packages fixes this error.